### PR TITLE
Fix broken libdebug build: Differing versions of crate `uuid`.

### DIFF
--- a/libdebug/Cargo.toml
+++ b/libdebug/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 gimli = "0.13.0"
 memmap = "0"
-uuid = "0.4"
-mach_object = "0.1.4"
+uuid = "0.5"
+mach_object = "0.1.5"
 if_chain = "^0.1.2"


### PR DESCRIPTION
This pull request should fix the following error during the release build of libdebug:

```
   --> src/read.rs:146:44
    |
146 |                             variant_uuid = uuid;
    |                                            ^^^^ expected struct `uuid::Uuid`, found a different struct `uuid::Uuid`
    |
    = note: expected type `uuid::Uuid` (struct `uuid::Uuid`)
               found type `uuid::Uuid` (struct `uuid::Uuid`)
note: Perhaps two different versions of crate `uuid` are being used?
```

This is due to a version mismatch between the following two dependencies:

```toml
uuid = "0.4"          # Installs 0.4.0
mach_object = "0.1.4" # Installs 0.1.5 and requires uuid 0.5.0
```

This pull request bumps `uuid` to `0.5`, since `mach_object` seems to pass all tests and everything compiles just fine afterwards. `mach_object` itself is bumped as well to make it more clear what crate version is being installed. Should the dependency maybe be locked to `=0.1.5` to avoid future issues like this? 